### PR TITLE
refs #7 S3バケット名を「${Env}-komatch」に変更する

### DIFF
--- a/komatch_s3.yml
+++ b/komatch_s3.yml
@@ -1,8 +1,20 @@
+---
 AWSTemplateFormatVersion: "2010-09-09"
+
 Description: Create S3 Bucket
+
+Parameters:
+  Env:
+    Type: String
+    Default: dev
+    Description: Select environment.
+    AllowedValues:
+    - prod
+    - dev
+
 Resources:
   S3:
     Type: AWS::S3::Bucket
     DeletionPolicy: Retain
-    Properties: 
-      BucketName: komatch-s3-20200807
+    Properties:
+      BucketName: !Sub "${Env}-komatch"


### PR DESCRIPTION
# 確認項目
- [x] コマンド実行により `dev-komatch` というS3バケットが作成される `dev-komatch-s3` スタックが作成できること
- [x] コマンド実行により `prod-komatch` というS3バケットが作成される `prod-komatch-s3` スタックが作成できること

# 備考
### `dev-komatch-s3` スタック作成コマンド

```bash
aws cloudformation deploy \
--template-file komatch_s3.yml \
--stack-name dev-komatch-s3 \
--capabilities CAPABILITY_IAM
```

### `prod-komatch-s3` 作成コマンド

```bash
aws cloudformation deploy \
--template-file komatch_s3.yml \
--stack-name prod-komatch-s3 \
--capabilities CAPABILITY_IAM \
--parameter-overrides Env=prod
```

### `dev-komatch-s3` スタック削除コマンド

```bash
aws cloudformation delete-stack --stack-name dev-komatch-s3
```

### `prod-komatch-s3` スタック削除コマンド

```bash
aws cloudformation delete-stack --stack-name prod-komatch-s3
```