### PR TITLE
refs #5 CloudFormationスタックをprodとdevで分ける

### DIFF
--- a/komatch_dynamodb.yml
+++ b/komatch_dynamodb.yml
@@ -1,10 +1,22 @@
+---
 AWSTemplateFormatVersion: 2010-09-09
+
 Description: Create DynamoDB Table
+
+Parameters:
+  Env:
+    Type: String
+    Default: dev
+    Description: Select environment.
+    AllowedValues:
+    - prod
+    - dev
+
 Resources:
   KomatchTable:
     Type: AWS::DynamoDB::Table
-    Properties: 
-      TableName: KomatchTable
+    Properties:
+      TableName: !Sub "${Env}-komatch"
       AttributeDefinitions:
         - AttributeName: id
           AttributeType: S
@@ -13,17 +25,17 @@ Resources:
         - AttributeName: data_value
           AttributeType: S
       KeySchema:
-        - AttributeName: id  
+        - AttributeName: id
           KeyType: HASH
         - AttributeName: data_type
           KeyType: RANGE
       GlobalSecondaryIndexes:
         - IndexName: GSI1
-          KeySchema: 
+          KeySchema:
             - AttributeName: data_value
               KeyType: HASH
           Projection:
-            ProjectionType: KEYS_ONLY 
+            ProjectionType: KEYS_ONLY
           ProvisionedThroughput:
             ReadCapacityUnits: 5
             WriteCapacityUnits: 5


### PR DESCRIPTION
# 概要
- DynamoDBのスタックのみ、他のIssueで対応できていないのでこちらで対応
- ymlに不要なスペース等が入っていたため併せて修正した
- テーブル名はそれぞれ `prod-komatch` `dev-komatch` で作成

# 確認項目
- [x] コマンド実行により `dev-komatch` というS3バケットが作成される `dev-komatch-s3` スタックが作成できること
- [x] コマンド実行により `prod-komatch` というS3バケットが作成される `prod-komatch-s3` スタックが作成できること

# 備考
### `dev-komatch-dynamodb` スタック作成コマンド

```bash
aws cloudformation deploy \
--template-file komatch_dynamodb.yml \
--stack-name dev-komatch-dynamodb \
--capabilities CAPABILITY_IAM
```

### `prod-komatch-dynamodb` 作成コマンド

```bash
aws cloudformation deploy \
--template-file komatch_dynamodb.yml \
--stack-name prod-komatch-dynamodb \
--capabilities CAPABILITY_IAM \
--parameter-overrides Env=prod
```

### `dev-komatch-dynamodb` スタック削除コマンド

```bash
aws cloudformation delete-stack --stack-name dev-komatch-dynamodb
```

### `prod-komatch-dynamodb` スタック削除コマンド

```bash
aws cloudformation delete-stack --stack-name prod-komatch-dynamodb
```