### PR TITLE
refs #10 slackAPIのチャレンジ認証処理を実装する

### DIFF
--- a/src/index.rb
+++ b/src/index.rb
@@ -1,3 +1,13 @@
+require 'json'
+
+ACK = {
+  statusCode: 200,
+  body: JSON.generate('OK')
+}.freeze
+
 def handler(event:, context:)
-  "Komatch"
+    return { challenge: event['challenge'] } if event['challenge']
+
+    ACK
 end
+


### PR DESCRIPTION
# 概要
- Lambda関数を変更し、チャレンジ認証が通るようにする
  - 具体的には、データとして `"{"challenge":"認証コード"}"` が渡されたリクエストの場合、`"{"challenge":"認証コード"}"` を返却するような作りにする

# 確認項目
- [ ] 以下実行してデータとして与えたものがそのまま返ってくること
```bash
curl -X POST -d '{"challenge":"チャレンジ認証"}' https://g5svdis29c.execute-api.ap-northeast-1.amazonaws.com/dev/komatch

# => {"challenge":"チャレンジ認証"}
```