### PR TITLE
refs #13 AppHomeタブを開いたら「Welcome to Komatch」が表示されるようにする

### DIFF
--- a/src/index/constants.rb
+++ b/src/index/constants.rb
@@ -13,6 +13,11 @@ ACK = {
 # Slack API URL
 SLACK_API_URL = 'https://slack.com/api'
 
+# Slack API Methods
+SLACK_API_METHODS = {
+  views_publish: 'views.publish'
+}
+
 # Homeタブ初期表示内容
 INITIAL_HOME_VIEW = {
   type: 'home',

--- a/src/index/constants.rb
+++ b/src/index/constants.rb
@@ -1,0 +1,26 @@
+### -------- ###
+### 定数管理 ###
+### -------- ###
+
+# 200レスポンス
+ACK = {
+  statusCode: 200,
+  body: JSON.generate('OK')
+}.freeze
+
+# Slack API URL
+SLACK_API_URL = 'https://slack.com/api'.freeze
+
+# Homeタブ初期表示内容
+INITIAL_HOME_VIEW = {
+  type: 'home',
+  blocks: [
+    {
+      type: 'section',
+      text: {
+        type: 'mrkdwn',
+        text: "Welcome to Komatch! (#{Time.now})"
+      }
+    }
+  ]
+}.to_json.freeze

--- a/src/index/constants.rb
+++ b/src/index/constants.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 ### -------- ###
 ### 定数管理 ###
 ### -------- ###
@@ -6,10 +8,10 @@
 ACK = {
   statusCode: 200,
   body: JSON.generate('OK')
-}.freeze
+}
 
 # Slack API URL
-SLACK_API_URL = 'https://slack.com/api'.freeze
+SLACK_API_URL = 'https://slack.com/api'
 
 # Homeタブ初期表示内容
 INITIAL_HOME_VIEW = {
@@ -23,4 +25,4 @@ INITIAL_HOME_VIEW = {
       }
     }
   ]
-}.to_json.freeze
+}.to_json

--- a/src/index/index.rb
+++ b/src/index/index.rb
@@ -1,9 +1,8 @@
+require 'aws-sdk'
 require 'json'
-
-ACK = {
-  statusCode: 200,
-  body: JSON.generate('OK')
-}.freeze
+require 'net/http'
+require 'uri'
+require_relative 'constants'
 
 def handler(event:, context:)
   puts '## Slackの情報'
@@ -12,6 +11,45 @@ def handler(event:, context:)
   # チャレンジ認証
   return { challenge: event['challenge'] } if event['challenge']
 
+  # Slack AppのHomeタブの初期表示処理
+  display_home(event['event']['user']) if event['event']['type'].to_s == 'app_home_opened'
+
   # 200ステータスを返す
   ACK
+end
+
+private
+
+# Slack AppのHomeタブの初期表示処理
+def display_home(user_id)
+  # POST実行準備
+  uri = URI.parse(File.join(SLACK_API_URL, 'views.publish'))
+  http = Net::HTTP.new(uri.host, uri.port)
+  http.use_ssl = uri.scheme === 'https'
+
+  # SSMパラメータストアから Slack Token を取得
+  ssm_client = Aws::SSM::Client.new
+  ssm_param = { name: "#{ENV['env']}_komatch_slack_token", with_decryption: true }
+  slack_token = ssm_client.get_parameter(ssm_param).parameter.value
+  # APIに渡すヘッダー
+  header = {
+    'Content-Type': 'application/json',
+    'Authorization': "Bearer #{slack_token}"
+  }
+  # APIに渡すパラメータ
+  params = {
+    user_id: user_id,
+    view: INITIAL_HOME_VIEW
+  }
+
+  # Homeタブ表示のAPI実行
+  response = http.post(uri.path, params.to_json, header)
+
+  # 実行結果ログ
+  puts '## user_id'
+  puts user_id
+  puts '## レスポンス：ステータスコード'
+  puts response.code
+  puts '## レスポンス：本文'
+  puts response.body
 end

--- a/src/index/index.rb
+++ b/src/index/index.rb
@@ -3,6 +3,7 @@ require 'json'
 require 'net/http'
 require 'uri'
 require_relative 'constants'
+require_relative 'private_methods'
 
 def handler(event:, context:)
   puts '## Slackの情報'
@@ -16,40 +17,4 @@ def handler(event:, context:)
 
   # 200ステータスを返す
   ACK
-end
-
-private
-
-# Slack AppのHomeタブの初期表示処理
-def display_home(user_id)
-  # POST実行準備
-  uri = URI.parse(File.join(SLACK_API_URL, 'views.publish'))
-  http = Net::HTTP.new(uri.host, uri.port)
-  http.use_ssl = uri.scheme === 'https'
-
-  # SSMパラメータストアから Slack Token を取得
-  ssm_client = Aws::SSM::Client.new
-  ssm_param = { name: "#{ENV['env']}_komatch_slack_token", with_decryption: true }
-  slack_token = ssm_client.get_parameter(ssm_param).parameter.value
-  # APIに渡すヘッダー
-  header = {
-    'Content-Type': 'application/json',
-    'Authorization': "Bearer #{slack_token}"
-  }
-  # APIに渡すパラメータ
-  params = {
-    user_id: user_id,
-    view: INITIAL_HOME_VIEW
-  }
-
-  # Homeタブ表示のAPI実行
-  response = http.post(uri.path, params.to_json, header)
-
-  # 実行結果ログ
-  puts '## user_id'
-  puts user_id
-  puts '## レスポンス：ステータスコード'
-  puts response.code
-  puts '## レスポンス：本文'
-  puts response.body
 end

--- a/src/index/private_methods.rb
+++ b/src/index/private_methods.rb
@@ -1,0 +1,49 @@
+private
+
+# Slack AppのHomeタブの初期表示処理
+def display_home(user_id)
+  # Slack API メソッド
+  slack_api_method = SLACK_API_METHODS[:views_publish]
+
+  # APIに渡すパラメータ
+  params = {
+    user_id: user_id,
+    view: INITIAL_HOME_VIEW
+  }
+
+  # Homeタブ表示のAPI実行
+  response = call_post_to_slack(slack_api_method, params)
+
+  # 実行結果ログ
+  puts '## user_id'
+  puts user_id
+  puts '## レスポンス：ステータスコード'
+  puts response.code
+  puts '## レスポンス：本文'
+  puts response.body
+end
+
+# Slack Token
+def slack_token
+  # SSMパラメータストアから Slack Token を取得
+  ssm_client = Aws::SSM::Client.new
+  ssm_param = { name: "#{ENV['env']}_komatch_slack_token", with_decryption: true }
+  ssm_client.get_parameter(ssm_param).parameter.value
+end
+
+# Slack API に対し POST リクエストを実行
+def call_post_to_slack(slack_api_method = nil, params = {})
+  # POST 実行 準備
+  uri = URI.parse(File.join(SLACK_API_URL, slack_api_method))
+  http = Net::HTTP.new(uri.host, uri.port)
+  http.use_ssl = uri.scheme === 'https'
+
+  # APIに渡すヘッダー
+  header = {
+    'Content-Type': 'application/json',
+    'Authorization': "Bearer #{slack_token}"
+  }
+
+  # POST 実行
+  http.post(uri.path, params.to_json, header)
+end

--- a/templates/komatch_sam.yml
+++ b/templates/komatch_sam.yml
@@ -133,6 +133,9 @@ Resources:
     Type: AWS::Serverless::Function
     Properties:
       FunctionName: !Sub "${Env}_Komatch_index"
+      Environment:
+        Variables:
+          env: !Sub "${Env}"
       Handler: index.handler
       MemorySize: 128
       Runtime: ruby2.7
@@ -202,5 +205,15 @@ Resources:
                   - dynamodb:Scan
                   - dynamodb:PutItem
                   - dynamodb:UpdateItem
+                Resource: "*"
+        - PolicyName: SystemManagerAccessFromLambda
+          PolicyDocument:
+            Version: 2012-10-17
+            Statement:
+              - Effect: Allow
+                Action:
+                  - ssm:Describe*
+                  - ssm:Get*
+                  - ssm:List*
                 Resource: "*"
       RoleName: !Sub "${Env}_KomatchLambdaRole"


### PR DESCRIPTION
# 概要
- AppHomeタブを開いたらSlackからAPI Gatewayにリクエストが飛んでくるため、それにより発火するLambdaでAppHomeタブに「Welcome to Komatch! （現時刻）」を表示するAPIを叩くメソッドを実装
- 叩くAPIはこちら https://api.slack.com/methods/views.publish
- APIを叩く際にslack tokenを入力する必要があるが、セキュアな管理方法として、まず手動でSSMパラメータストアに登録し、その値をLambda内で取得するような処理にしている

# 確認項目
- [ ] コードに不備がないこと
- [ ] こまっちのHomeタブを開くと「Welcome to Komatch! （現時刻）」が表示されること

# 備考