### PR TITLE
#35 dev1, dev2, dev3のスタックを作成する

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,9 @@
+# ディレクトリ構成
+- `script` ...デプロイコマンドを記述したファイルを配置
+- `src` ...Lambda実行関数ファイルを配置
+- `templates` ...CloudFormation, SAM 実行ymlを配置
+- `test` ...Lambda実行関数のテストコードファイルを配置
+
 # デプロイコマンド
 ## dev
 ### S3
@@ -6,6 +12,14 @@
 `sh script/deploy_dev-komatch-dynamodb`
 ### SAM
 `sh script/deploy_dev-komatch-sam`
+
+## dev1, dev2, dev3
+### S3
+`sh script/deploy_dev${i}-komatch-s3`
+### DynamoDB
+`sh script/deploy_dev${i}-komatch-dynamodb`
+### SAM
+`sh script/deploy_dev${i}-komatch-sam`
 
 ## prod
 ### S3

--- a/script/deploy_dev1-komatch-dynamodb
+++ b/script/deploy_dev1-komatch-dynamodb
@@ -1,0 +1,10 @@
+#!/bin/sh
+
+# 実行ディレクトリの指定
+cd `dirname $0`/../
+
+# CFnスタック デプロイコマンド
+aws cloudformation deploy \
+  --template-file templates/komatch_dynamodb.yml \
+  --stack-name dev1-komatch-dynamodb \
+  --parameter-overrides Env=dev1

--- a/script/deploy_dev1-komatch-s3
+++ b/script/deploy_dev1-komatch-s3
@@ -1,0 +1,10 @@
+#!/bin/sh
+
+# 実行ディレクトリの指定
+cd `dirname $0`/../
+
+# CFnスタック デプロイコマンド
+aws cloudformation deploy \
+  --template-file templates/komatch_s3.yml \
+  --stack-name dev1-komatch-s3 \
+  --parameter-overrides Env=dev1

--- a/script/deploy_dev1-komatch-sam
+++ b/script/deploy_dev1-komatch-sam
@@ -1,0 +1,13 @@
+#!/bin/sh
+
+# 実行ディレクトリの指定
+cd `dirname $0`/../
+
+# SAMデプロイコマンド
+sam deploy \
+  --template-file templates/komatch_sam.yml \
+  --stack-name dev1-komatch-sam \
+  --s3-bucket dev1-komatch \
+  --confirm-changeset \
+  --capabilities CAPABILITY_NAMED_IAM \
+  --parameter-overrides Env=dev1

--- a/script/deploy_dev2-komatch-dynamodb
+++ b/script/deploy_dev2-komatch-dynamodb
@@ -1,0 +1,10 @@
+#!/bin/sh
+
+# 実行ディレクトリの指定
+cd `dirname $0`/../
+
+# CFnスタック デプロイコマンド
+aws cloudformation deploy \
+  --template-file templates/komatch_dynamodb.yml \
+  --stack-name dev2-komatch-dynamodb \
+  --parameter-overrides Env=dev2

--- a/script/deploy_dev2-komatch-s3
+++ b/script/deploy_dev2-komatch-s3
@@ -1,0 +1,10 @@
+#!/bin/sh
+
+# 実行ディレクトリの指定
+cd `dirname $0`/../
+
+# CFnスタック デプロイコマンド
+aws cloudformation deploy \
+  --template-file templates/komatch_s3.yml \
+  --stack-name dev2-komatch-s3 \
+  --parameter-overrides Env=dev2

--- a/script/deploy_dev2-komatch-sam
+++ b/script/deploy_dev2-komatch-sam
@@ -1,0 +1,13 @@
+#!/bin/sh
+
+# 実行ディレクトリの指定
+cd `dirname $0`/../
+
+# SAMデプロイコマンド
+sam deploy \
+  --template-file templates/komatch_sam.yml \
+  --stack-name dev2-komatch-sam \
+  --s3-bucket dev2-komatch \
+  --confirm-changeset \
+  --capabilities CAPABILITY_NAMED_IAM \
+  --parameter-overrides Env=dev2

--- a/script/deploy_dev3-komatch-dynamodb
+++ b/script/deploy_dev3-komatch-dynamodb
@@ -1,0 +1,10 @@
+#!/bin/sh
+
+# 実行ディレクトリの指定
+cd `dirname $0`/../
+
+# CFnスタック デプロイコマンド
+aws cloudformation deploy \
+  --template-file templates/komatch_dynamodb.yml \
+  --stack-name dev3-komatch-dynamodb \
+  --parameter-overrides Env=dev3

--- a/script/deploy_dev3-komatch-s3
+++ b/script/deploy_dev3-komatch-s3
@@ -1,0 +1,10 @@
+#!/bin/sh
+
+# 実行ディレクトリの指定
+cd `dirname $0`/../
+
+# CFnスタック デプロイコマンド
+aws cloudformation deploy \
+  --template-file templates/komatch_s3.yml \
+  --stack-name dev3-komatch-s3 \
+  --parameter-overrides Env=dev3

--- a/script/deploy_dev3-komatch-sam
+++ b/script/deploy_dev3-komatch-sam
@@ -1,0 +1,13 @@
+#!/bin/sh
+
+# 実行ディレクトリの指定
+cd `dirname $0`/../
+
+# SAMデプロイコマンド
+sam deploy \
+  --template-file templates/komatch_sam.yml \
+  --stack-name dev3-komatch-sam \
+  --s3-bucket dev3-komatch \
+  --confirm-changeset \
+  --capabilities CAPABILITY_NAMED_IAM \
+  --parameter-overrides Env=dev3

--- a/templates/komatch_dynamodb.yml
+++ b/templates/komatch_dynamodb.yml
@@ -9,6 +9,12 @@ Mappings:
       DynamoDBTableName: ProdKomatch
     dev:
       DynamoDBTableName: DevKomatch
+    dev1:
+      DynamoDBTableName: Dev1Komatch
+    dev2:
+      DynamoDBTableName: Dev2Komatch
+    dev3:
+      DynamoDBTableName: Dev3Komatch
 
 Parameters:
   Env:
@@ -18,6 +24,9 @@ Parameters:
     AllowedValues:
     - prod
     - dev
+    - dev1
+    - dev2
+    - dev3
 
 Resources:
   KomatchTable:

--- a/templates/komatch_s3.yml
+++ b/templates/komatch_s3.yml
@@ -11,6 +11,9 @@ Parameters:
     AllowedValues:
     - prod
     - dev
+    - dev1
+    - dev2
+    - dev3
 
 Resources:
   S3:

--- a/templates/komatch_sam.yml
+++ b/templates/komatch_sam.yml
@@ -9,6 +9,12 @@ Mappings:
       ApiGatewayModelName: ProdKomatchSchema
     dev:
       ApiGatewayModelName: DevKomatchSchema
+    dev1:
+      ApiGatewayModelName: Dev1KomatchSchema
+    dev2:
+      ApiGatewayModelName: Dev2KomatchSchema
+    dev3:
+      ApiGatewayModelName: Dev3KomatchSchema
 
 Parameters:
   Env:
@@ -18,6 +24,9 @@ Parameters:
     AllowedValues:
     - prod
     - dev
+    - dev1
+    - dev2
+    - dev3
 
 Resources:
   # API Gateway RestAPI


### PR DESCRIPTION
# 概要
- dev1, dev2, dev3のS3, DynamoDB, サーバレスの各スタックを作成するため、ParametersのEnvに `dev1` `dev2` `dev3` を追加
- デプロイコマンドファイルも追加
- `README.md` を更新

# 確認項目
- dev1, dev2, dev3のスタックがそれぞれ作成されており、問題なく開発環境として使用できそうであること

# 備考
- devスタックは、実質stg環境のような、最新のmasterブランチが反映される環境として使っていきたい
- slack APIのRequest URLは、dev1, dev2, dev3を使用する際に適宜slack API側で変更する方法で暫定的に行う