### PR TITLE
refs #18 キーワード抽出の実装

### DIFF
--- a/src/extract_keywords/comprehend.rb
+++ b/src/extract_keywords/comprehend.rb
@@ -1,8 +1,21 @@
 require 'aws-sdk'
+require_relative 'private_methods'
 
-def handler(event:, _context:)
-  client = Aws::Comprehend::Client.new
-  resp   = client.detect_key_phrases({ text: event['text'], language_code: 'ja' })
+def handler(event:, context:)
+  puts '## キーワード抽出'
 
-  { keywords: resp.key_phrases.map(&:text).uniq }.to_json
+  # textがなかったら空で返す
+  text = event['text']
+  return response_with_keywords([]) if text.empty?
+
+  puts '## 質問原文'
+  puts text
+
+  # キーワード抽出
+  client   = Aws::Comprehend::Client.new
+  resp     = client.detect_key_phrases({ text: text, language_code: 'ja' })
+  keywords = resp.key_phrases.map(&:text).uniq
+
+  # 抽出したキーワードをjsonで返す
+  response_with_keywords(keywords)
 end

--- a/src/extract_keywords/comprehend.rb
+++ b/src/extract_keywords/comprehend.rb
@@ -1,0 +1,8 @@
+require 'aws-sdk'
+
+def handler(event:, _context:)
+  client = Aws::Comprehend::Client.new
+  resp   = client.detect_key_phrases({ text: event['text'], language_code: 'ja' })
+
+  { keywords: resp.key_phrases.map(&:text).uniq }.to_json
+end

--- a/src/extract_keywords/private_methods.rb
+++ b/src/extract_keywords/private_methods.rb
@@ -1,0 +1,7 @@
+private
+
+def response_with_keywords(keywords)
+  puts '## 抽出したキーワード'
+  puts keywords.join(', ')
+  { keywords: keywords }.to_json
+end

--- a/templates/komatch_sam.yml
+++ b/templates/komatch_sam.yml
@@ -167,6 +167,41 @@ Resources:
             - Ref: SlackApiGatewayRestApi
             - /*/*/*
 
+  ExtractKeywordsFunction:
+    Type: AWS::Serverless::Function
+    Properties:
+      FunctionName: !Sub "${Env}_Komatch_extract_keywords"
+      Handler: comprehend.handler
+      MemorySize: 128
+      Runtime: ruby2.7
+      CodeUri: ../src/extract_keywords
+      Role:
+        Fn::GetAtt:
+          - LambdaIAMRole
+          - Arn
+      Timeout: 10
+
+  ExtractKeywordsPermission:
+    Type: AWS::Lambda::Permission
+    Properties:
+      Action: lambda:invokeFunction
+      FunctionName:
+         Fn::GetAtt:
+          - ExtractKeywordsFunction
+          - Arn
+      Principal: apigateway.amazonaws.com
+      SourceArn:
+        Fn::Join:
+          - ""
+          - - arn:aws:execute-api
+            - ":"
+            - Ref: AWS::Region
+            - ":"
+            - Ref: AWS::AccountId
+            - ":"
+            - Ref: SlackApiGatewayRestApi
+            - /*/*/*
+
   # IAM Role
   LambdaIAMRole:
     Type: AWS::IAM::Role
@@ -215,5 +250,13 @@ Resources:
                   - ssm:Describe*
                   - ssm:Get*
                   - ssm:List*
+                Resource: "*"
+        - PolicyName: ComprehendAccessFromLambda
+          PolicyDocument:
+            Version: 2012-10-17
+            Statement:
+              - Effect: Allow
+                Action:
+                  - comprehend:Detect*
                 Resource: "*"
       RoleName: !Sub "${Env}_KomatchLambdaRole"


### PR DESCRIPTION
## 概要
#18( #32 )

`text`を受け取るとキーワードを抽出してjsonの形式でキーワードを出力します。
(エラーについては未考慮なので、後ほど修正します。)

## 確認事項
- [ ] 関数名等が`extract_keywords` になっていること
- [ ] jsonでの出力になっていること

## 備考
rubocopで `Style/FrozenStringLiteralComment: Missing frozen string literal comment.` だけ出てます。