### PR TITLE
refs #28 ユーザー情報登録・更新のLambda(fn: get_users)を定時実行化する

### DIFF
--- a/src/get_users/get_users.rb
+++ b/src/get_users/get_users.rb
@@ -7,10 +7,20 @@ def handler(event:, context:)
   table_name = ENV['DDB_TABLE']
 
   url = SLACK_API_URL + "/users.list?token=#{slack_token}"
-  members_info = JSON.parse(URI.open(url).read)['members']
+  users_info = JSON.parse(URI.open(url).read)['members']
 
-  table_name = ENV['DDB_TABLE']
-  items = dynamodb.scan({ table_name: table_name })
+  attrs = %w[name team_id]
+
+  users_info.each do |user_info|
+    attrs.each do |attr|
+      item = {
+        id: user_info['id'],
+        data_type: attr,
+        data_value: user_info[attr]
+      }
+      dynamodb.put_item({ table_name: table_name, item: item })
+    end
+  end
 
   # 200ステータスを返す
   ACK

--- a/templates/komatch_sam.yml
+++ b/templates/komatch_sam.yml
@@ -213,6 +213,11 @@ Resources:
           - LambdaIAMRole
           - Arn
       Timeout: 10
+      Events:
+        Timer:
+          Type: Schedule
+          Properties:
+            Schedule: rate(24 hours)
 
   RegisterQuestionFunction:
     Type: AWS::Serverless::Function


### PR DESCRIPTION
# 概要
- ワークスペースからユーザー情報を取得し、DynamoDBに登録する
- 登録を定時実行化
  - 24時間ごとに実行されるようにしてあります
  - テンプレートのEventで細かく設定することができます