### PR TITLE
refs #28 data_typeをテーブル定義書に合わせる・batch_write_itemを使ってアイテムを作成するように修正

### DIFF
--- a/lib/ruby/lib/layer_methods.rb
+++ b/lib/ruby/lib/layer_methods.rb
@@ -61,3 +61,20 @@ def put_item(id, data_type, data_value)
     }
   )
 end
+
+# 一度に複数アイテム作成
+def batch_write_item(items)
+  dynamodb.batch_write_item({ request_items: { table_name => items } })
+end
+
+def generate_item_for_batch_write(id, key, value)
+  {
+    put_request: {
+      item: {
+        id: id,
+        data_type: key,
+        data_value: value
+      }
+    }
+  }
+end

--- a/src/get_users/get_users.rb
+++ b/src/get_users/get_users.rb
@@ -3,16 +3,16 @@ require 'uri'
 require 'layer_constants'
 require 'layer_methods'
 
+ATTRS = { Name: 'name', WorkspaceId: 'team_id' }.freeze
+
 def handler(event:, context:)
   url = SLACK_API_URL + "/users.list?token=#{slack_token}"
   users_info = JSON.parse(URI.open(url).read)['members']
 
-  attrs = %w[name team_id]
-
+  # 1度にPUTできる数は25とのことなので、ユーザー毎に必要なアイテムをPUTする
   users_info.each do |user_info|
-    attrs.each do |attr|
-      put_item(user_info['id'], attr, user_info[attr])
-    end
+    items = ATTRS.map { |k, v| generate_item_for_batch_write(user_info['id'], k, user_info[v]) }
+    batch_write_item(items)
   end
 
   # 200ステータスを返す

--- a/templates/komatch_sam.yml
+++ b/templates/komatch_sam.yml
@@ -356,6 +356,7 @@ Resources:
                   - dynamodb:Scan
                   - dynamodb:PutItem
                   - dynamodb:UpdateItem
+                  - dynamodb:BatchWriteItem
                 Resource: "*"
         - PolicyName: SystemManagerAccessFromLambda
           PolicyDocument:


### PR DESCRIPTION
* Lambdaのテストを実行した時に、DynamoDBにユーザー識別用のアイテムが作成されること
* `batch_write_item` が共通化されていること