### PR TITLE
refs #27 DynamoDBから取得したユーザーに対して、slackで通知する

### DIFF
--- a/lib/ruby/lib/layer_constants.rb
+++ b/lib/ruby/lib/layer_constants.rb
@@ -21,17 +21,3 @@ SLACK_API_METHODS = {
   views_open: 'views.open',
   post_message: 'chat.postMessage'
 }.freeze
-
-# Homeタブ初期表示内容
-INITIAL_HOME_VIEW = {
-  type: 'home',
-  blocks: [
-    {
-      type: 'section',
-      text: {
-        type: 'mrkdwn',
-        text: "Welcome to Komatch! (#{Time.now})"
-      }
-    }
-  ]
-}.to_json

--- a/lib/ruby/lib/layer_constants.rb
+++ b/lib/ruby/lib/layer_constants.rb
@@ -10,7 +10,7 @@ require 'json'
 ACK = {
   statusCode: 200,
   body: JSON.generate('OK')
-}
+}.freeze
 
 # Slack API URL
 SLACK_API_URL = 'https://slack.com/api'

--- a/lib/ruby/lib/layer_constants.rb
+++ b/lib/ruby/lib/layer_constants.rb
@@ -18,5 +18,20 @@ SLACK_API_URL = 'https://slack.com/api'
 # Slack API Methods
 SLACK_API_METHODS = {
   views_publish: 'views.publish',
-  views_open: 'views.open'
-}
+  views_open: 'views.open',
+  post_message: 'chat.postMessage'
+}.freeze
+
+# Homeタブ初期表示内容
+INITIAL_HOME_VIEW = {
+  type: 'home',
+  blocks: [
+    {
+      type: 'section',
+      text: {
+        type: 'mrkdwn',
+        text: "Welcome to Komatch! (#{Time.now})"
+      }
+    }
+  ]
+}.to_json

--- a/src/messenger/messenger.rb
+++ b/src/messenger/messenger.rb
@@ -6,7 +6,7 @@ def handler(event:, context:)
 
   slack_api_method = SLACK_API_METHODS[:post_message]
   target_users(event).items.each do |user|
-    params = { channel: "@#{user['id']}", text: '相談が届きました。' }
+    params = { channel: "@#{user['id']}", blocks: create_blocks }
     response = call_post_to_slack(slack_api_method, params)
     put_log(user, response)
   end
@@ -14,7 +14,7 @@ end
 
 private
 
-# TODO: キーワードから抽出したユーザーを取得できるようにする
+# TODO: StepFunctionsとのつなぎこみ時に削除
 def target_users(_event)
   dynamodb.query(
     table_name: ENV['DDB_TABLE'],
@@ -35,4 +35,40 @@ def put_log(user, response)
   puts response.code
   puts '## レスポンス：本文'
   puts response.body
+end
+
+def create_blocks
+  [
+    create_text('相談が届きました。'),
+    {
+      'type': 'actions',
+      'elements': [
+        create_button('OK'),
+        create_button('NG')
+      ]
+    }
+  ]
+end
+
+def create_text(text)
+  {
+    'type': 'section',
+    'text': {
+      'type': 'plain_text',
+      'text': text,
+      'emoji': true
+    }
+  }
+end
+
+def create_button(text)
+  {
+    'type': 'button',
+    'text': {
+      'type': 'plain_text',
+      'text': text,
+      'emoji': true
+    },
+    'value': 'click_me_123'
+  }
 end

--- a/src/messenger/messenger.rb
+++ b/src/messenger/messenger.rb
@@ -1,4 +1,38 @@
+require 'layer_constants'
+require 'layer_methods'
+
 def handler(event:, context:)
   puts '## 質問の通知'
-  # TODO: 実装
+
+  slack_api_method = SLACK_API_METHODS[:post_message]
+  target_users(event).items.each do |user|
+    params = { channel: "@#{user['id']}", text: '相談が届きました。' }
+    response = call_post_to_slack(slack_api_method, params)
+    put_log(user, response)
+  end
+end
+
+private
+
+# TODO: キーワードから抽出したユーザーを取得できるようにする
+def target_users(_event)
+  dynamodb.query(
+    table_name: ENV['DDB_TABLE'],
+    index_name: 'GSI1',
+    projection_expression: 'id',
+    key_condition_expression: 'data_value = :data_value',
+    expression_attribute_values: {
+      ':data_value' => 'T017X0LTP42'
+    }
+  )
+end
+
+def put_log(user, response)
+  # 実行結果ログ
+  puts '## user'
+  puts user
+  puts '## レスポンス：ステータスコード'
+  puts response.code
+  puts '## レスポンス：本文'
+  puts response.body
 end

--- a/templates/komatch_sam.yml
+++ b/templates/komatch_sam.yml
@@ -280,6 +280,13 @@ Resources:
         Fn::GetAtt:
           - LambdaIAMRole
           - Arn
+      Layers:
+        - !Ref LibsLayer
+      Environment:
+        Variables:
+          DDB_TABLE:
+            Fn::ImportValue: !Sub "${Env}-DynamoDBTable"
+          env: !Sub "${Env}"
       Timeout: 10
 
   # StepFunctions


### PR DESCRIPTION
* Lambdaのテストを実行した際に、こまっちから「OK」「NG」のボタンが表示されたメッセージが届くこと(ひとまずワークスペースに所属するすべての人に届くようになっているので、もし気になるのであればデータを削除してから実施してください)
* rubocopで警告が出ないこと