### PR TITLE
ref #33 register_questionの定義

### DIFF
--- a/src/register_question/register_question.rb
+++ b/src/register_question/register_question.rb
@@ -1,4 +1,23 @@
+require 'securerandom'
+require 'layer_constants'
+require 'layer_methods'
+
 def handler(event:, context:)
-  puts '## 質問登録'
-  # TODO: 実装
+  # Featureは配列が入るので処理を分けている
+  string_attrs = { UserId: event['user_id'], Body: event['body'] }
+  array_attrs = { Feature: event['feature_tag'] }
+  id = SecureRandom.alphanumeric(10)
+
+  string_attrs.each do |data_type, data_value|
+    put_item(id, data_type, data_value)
+  end
+
+  array_attrs.each do |data_type, data_value|
+    data_value.each do |value|
+      put_item(id, data_type.to_s + '_' + value, value)
+    end
+  end
+
+  # 200ステータスを返す
+  ACK
 end

--- a/src/register_question/register_question.rb
+++ b/src/register_question/register_question.rb
@@ -5,7 +5,7 @@ require 'layer_methods'
 def handler(event:, context:)
   # Featureは配列が入るので処理を分けている
   string_attrs = { UserId: event['user_id'], Body: event['body'] }
-  array_attrs = { Feature: event['feature_tag'] }
+  array_attrs = { Feature: event['keywords'] }
   id = SecureRandom.alphanumeric(10)
 
   string_attrs.each do |data_type, data_value|

--- a/templates/komatch_sam.yml
+++ b/templates/komatch_sam.yml
@@ -229,6 +229,13 @@ Resources:
       MemorySize: 128
       Runtime: ruby2.7
       CodeUri: ../src/register_question
+      Layers:
+        - !Ref LibsLayer
+      Environment:
+        Variables:
+          DDB_TABLE:
+            Fn::ImportValue: !Sub "${Env}-DynamoDBTable"
+          env: !Sub "${Env}"
       Role:
         Fn::GetAtt:
           - LambdaIAMRole


### PR DESCRIPTION
# 概要
extract_keywordから受け取った質問情報とキーワードをDynamo DBに登録するLambda(fn: register_question)の定義
# 確認事項
- [クエリ条件定義(シート2)](https://appirits.quip.com/U3HsAUtShhpb#DHDACA619V5)の8, 9, 11行目に沿った実装になっていること
- Dynamo DBに値が登録されていること（dev3環境にデプロイ済み）
## 想定される入力
```
{
  "user_id": "ID123",
  "body": "text",
  "keywords": [
    "Ruby",
    "Python",
    "Go"
  ]
}
```