### PR TITLE
refs #49 相談概要投稿後に完了の旨のメッセージを含むモーダル表示に変更する

### DIFF
--- a/src/index/index.rb
+++ b/src/index/index.rb
@@ -23,8 +23,8 @@ def handler(event:, context:)
   render_question_post_modal(body)
 
   # 相談概要投稿受信処理
-  recieve_question_post(body)
+  res = recieve_question_post(body)
 
   # 200ステータスを返す
-  ACK
+  res || ACK
 end

--- a/src/index/require_files/display_home.rb
+++ b/src/index/require_files/display_home.rb
@@ -8,7 +8,7 @@ def display_home(event)
   return unless event['type'].to_s == 'app_home_opened'
 
   # APIリクエストから user_id を取得
-  user_id = event['user_id']
+  user_id = event['user']
 
   # Slack API メソッド
   slack_api_method = SLACK_API_METHODS[:views_publish]


### PR DESCRIPTION
# 概要
- 相談概要入力後にslackエラーみたいなものが出てしまっている問題を解決

# 確認項目
- 相談概要を投稿すると以下のようなモーダル表示に変わること
![スクリーンショット 2020-08-26 18 27 32](https://user-images.githubusercontent.com/48672828/91287714-0e267480-e7cb-11ea-83f7-278c82efd79e.png)

- 相談概要を投稿すると以下のようなメッセージがこまっちから送信されること
![スクリーンショット 2020-08-26 18 27 41](https://user-images.githubusercontent.com/48672828/91287762-1bdbfa00-e7cb-11ea-8c11-e00c9998e7a2.png)
